### PR TITLE
Ensure own-property links are HTTPS in search results

### DIFF
--- a/src/JNCC.PublicWebsite.Core/JNCC.PublicWebsite.Core.csproj
+++ b/src/JNCC.PublicWebsite.Core/JNCC.PublicWebsite.Core.csproj
@@ -463,6 +463,7 @@
     <Compile Include="Services\ScienceCategoryPageService.cs" />
     <Compile Include="Services\SearchIndexingQueueService.cs" />
     <Compile Include="Services\SidebarServiceBase.cs" />
+    <Compile Include="Utilities\LinkUtility.cs" />
     <Compile Include="ViewModels\GenericListingPageItemViewModel.cs" />
     <Compile Include="ViewModels\IFramePageViewModel.cs" />
     <Compile Include="ViewModels\ImageGalleryItemViewModel.cs" />

--- a/src/JNCC.PublicWebsite.Core/Utilities/LinkUtility.cs
+++ b/src/JNCC.PublicWebsite.Core/Utilities/LinkUtility.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace JNCC.PublicWebsite.Core.Utilities
+{
+    public static class LinkUtility
+    {
+        public static string EnsureHttpsForJnccLinks(string url)
+        {
+            if (Uri.TryCreate(url, UriKind.Absolute, out Uri uri))
+            {
+                if (uri.Host.Contains("jncc.gov.uk"))
+                {
+                    var b = new UriBuilder(uri)
+                    {
+                        Scheme = Uri.UriSchemeHttps,
+                        Port = -1 // default port for scheme
+                    };
+
+                    return b.ToString();
+                }
+            }
+
+            return url;
+        }
+    }
+}

--- a/src/JNCC.PublicWebsite/Views/SearchResultsPage.cshtml
+++ b/src/JNCC.PublicWebsite/Views/SearchResultsPage.cshtml
@@ -25,7 +25,7 @@
                         foreach (var result in Model.PagedResults)
                         {
                             <h3><a href="@LinkUtility.EnsureHttpsForJnccLinks(result.Url)">@result.Title</a></h3>
-                            <p>Published: @result.PublishedDate @if (string.IsNullOrWhiteSpace(result.FileExtension) == false){<text>| File Extension: </text>@result.FileExtension}</p>
+                            <p>Published: @result.PublishedDate @if (string.IsNullOrWhiteSpace(result.FileExtension) == false) {<text>| File Extension: </text>@result.FileExtension}</p>
                             <p class="resultContent">@result.Content</p>
                             <hr />
                         }

--- a/src/JNCC.PublicWebsite/Views/SearchResultsPage.cshtml
+++ b/src/JNCC.PublicWebsite/Views/SearchResultsPage.cshtml
@@ -2,6 +2,9 @@
 @{
     Layout = "Master.cshtml";
 }
+
+@using JNCC.PublicWebsite.Core.Utilities
+
 <main id="main">
     @(Html.Action<PageHeroSurfaceController>("RenderPageHero"))
     <div class="container">
@@ -23,7 +26,7 @@
                     {
                         foreach (var result in Model.PagedResults)
                         {
-                            <h3><a href="@result.Url">@result.Title</a></h3>
+                            <h3><a href="@LinkUtility.EnsureHttpsForJnccLinks(result.Url)">@result.Title</a></h3>
                             <p>Published: @result.PublishedDate @if (string.IsNullOrWhiteSpace(result.FileExtension) == false) {<text>| File Extension: </text>@result.FileExtension}</p>
                             <p class="resultContent">@result.Content</p>
                             <hr />

--- a/src/JNCC.PublicWebsite/Views/SearchResultsPage.cshtml
+++ b/src/JNCC.PublicWebsite/Views/SearchResultsPage.cshtml
@@ -1,10 +1,8 @@
-﻿@model SearchViewModel
+﻿@using JNCC.PublicWebsite.Core.Utilities
+@model SearchViewModel
 @{
     Layout = "Master.cshtml";
 }
-
-@using JNCC.PublicWebsite.Core.Utilities
-
 <main id="main">
     @(Html.Action<PageHeroSurfaceController>("RenderPageHero"))
     <div class="container">
@@ -27,7 +25,7 @@
                         foreach (var result in Model.PagedResults)
                         {
                             <h3><a href="@LinkUtility.EnsureHttpsForJnccLinks(result.Url)">@result.Title</a></h3>
-                            <p>Published: @result.PublishedDate @if (string.IsNullOrWhiteSpace(result.FileExtension) == false) {<text>| File Extension: </text>@result.FileExtension}</p>
+                            <p>Published: @result.PublishedDate @if (string.IsNullOrWhiteSpace(result.FileExtension) == false){<text>| File Extension: </text>@result.FileExtension}</p>
                             <p class="resultContent">@result.Content</p>
                             <hr />
                         }


### PR DESCRIPTION
Hello C6 :smiley: Here is a patch to ensure that search result links for any JNCC site are written as HTTPS links. I've been unable to run the website locally, and although it compiles fine the search results page fails at runtime for some reason. More explanation in ticket.   :hear_no_evil: